### PR TITLE
GH-13-clean-and-update-reexports-of-the-library

### DIFF
--- a/canyon_crud/Cargo.toml
+++ b/canyon_crud/Cargo.toml
@@ -3,11 +3,8 @@ name = "canyon_crud"
 version = "1.0.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.9.0", features = ["full"] }
 async-trait = { version = "0.1.50" }
 
 canyon_connection = { path = "../canyon_connection" }

--- a/canyon_crud/src/crud.rs
+++ b/canyon_crud/src/crud.rs
@@ -152,7 +152,7 @@ mod postgres_query_launcher {
         let (client, connection) =
             (postgres_connection.client, postgres_connection.connection);
 
-        tokio::spawn(async move {
+        canyon_connection::tokio::spawn(async move {
             if let Err(e) = connection.await {
                 eprintln!("An error occured while trying to connect to the database: {}", e);
             }


### PR DESCRIPTION
#13 Clean up of the deps and the reexports in between crates to the root one `canyon_sql`. 

Later, we'll focus on what things are reexported from the root, and how they are reexported (paths, vis...)