### PR TITLE
Reworking the Canyon Connector

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,6 +25,12 @@ jobs:
         run: |
           rustup toolchain install nightly
           rustup override set nightly
+
+      - name: Make the USER own the working directory. Installing `gssapi` headers
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+          sudo apt -y install gcc libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit
       
       - name: Caching cargo dependencies
         id: project-cache

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Make the USER own the working directory. Installing `gssapi` headers
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+          sudo apt -y install gcc libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit
+
       - name: Caching project dependencies
         id: project-cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: hecrj/setup-rust-action@v1
         with:
           components: clippy
-      - run: cargo clippy --workspace --all-targets --verbose --all-features -- -A clippy::question_mark
+      - run: cargo clippy --workspace --all-targets --verbose --all-features
   rustfmt:
     name: Verify code formatting
     runs-on: ubuntu-latest
@@ -57,4 +57,4 @@ jobs:
         with:
           rust-version: nightly
 
-      - run: cargo rustdoc -p ${{ matrix.crate }} --all-features -- -D warnings
+      - run: cargo rustdoc --target=x86_64-unknown-linux-gnu -p ${{ matrix.crate }} --all-features -- -D warnings

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,6 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Make the USER own the working directory. Installing `gssapi` headers
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+          sudo apt -y install gcc libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit
+
       - name: Caching project dependencies
         id: project-cache
         uses: Swatinem/rust-cache@v2
@@ -53,6 +58,11 @@ jobs:
         crate: [canyon_connection, canyon_crud, canyon_macros, canyon_observer, canyon_sql]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Make the USER own the working directory. Installing `gssapi` headers
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+          sudo apt -y install gcc libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit
 
       - name: Caching project dependencies
         id: project-cache

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,12 +43,16 @@ jobs:
 
       - name: Load data for MSSQL tests
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: cargo test initialize_sql_server_docker_instance -p tests --all-features --no-fail-fast -- --show-output --nocapture --include-ignored
+        run: cargo test initialize_sql_server_docker_instance -p tests --target=x86_64-unknown-linux-gnu --all-features --no-fail-fast -- --show-output --nocapture --include-ignored
 
       - name: Run all tests, UNIT and INTEGRATION for Linux targets
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: cargo test --verbose --workspace --all-features --no-fail-fast -- --show-output --test-threads=1
 
-      - name: Run only UNIT tests for the rest of the defined targets
-        if: ${{ matrix.os != 'ubuntu-latest' }}
+      - name: Run only UNIT tests for Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: cargo test --verbose --workspace --target=x86_64-pc-windows-msvc --exclude tests --all-features --no-fail-fast -- --show-output-
+
+      - name: Run only UNIT tests for MacOS
+        if: ${{ matrix.os == 'MacOS-latest' }}
         run: cargo test --verbose --workspace --exclude tests --all-features --no-fail-fast -- --show-output

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run only UNIT tests for Windows
         if: ${{ matrix.os == 'windows-latest' }}
-        run: cargo test --verbose --workspace --target=x86_64-pc-windows-msvc --exclude tests --all-features --no-fail-fast -- --show-output-
+        run: cargo test --verbose --workspace --target=x86_64-pc-windows-msvc --exclude tests --all-features --no-fail-fast -- --show-output
 
       - name: Run only UNIT tests for MacOS
         if: ${{ matrix.os == 'MacOS-latest' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,8 @@ jobs:
         - { rust: stable,            os: windows-latest }
 
     steps:
-      - name: Upgrading Rust
-        run: rustup update
+      - name: Installing vendored OpenSSL
+        run: cargo install cargo-generate --features vendored-openssl
 
       - name: Make the USER own the working directory
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,9 @@ jobs:
         - { rust: stable,            os: windows-latest }
 
     steps:
+      - name: Upgrading Rust
+        run: rustup update
+
       - name: Make the USER own the working directory
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: sudo chown -R $USER:$USER ${{ github.workspace }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,6 @@ jobs:
         - { rust: stable,            os: windows-latest }
 
     steps:
-      - name: Installing vendored OpenSSL
-        run: cargo install cargo-generate --features vendored-openssl
-
       - name: Make the USER own the working directory. Installing `gssapi` headers
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,9 +26,11 @@ jobs:
       - name: Installing vendored OpenSSL
         run: cargo install cargo-generate --features vendored-openssl
 
-      - name: Make the USER own the working directory
+      - name: Make the USER own the working directory. Installing `gssapi` headers
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo chown -R $USER:$USER ${{ github.workspace }}
+        run: |
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+          sudo apt -y install gcc libgssapi-krb5-2 libkrb5-dev libsasl2-modules-gssapi-mit
       
       - uses: actions/checkout@v3
 

--- a/bash_aliases.sh
+++ b/bash_aliases.sh
@@ -4,7 +4,7 @@
 # This alias avoid the usage of a bunch of commands for performn an integrated task that 
 # depends on several concatenated commands.
 
-# In order to run the script, simply type `$ . ./alias.sh` from the root of the project.
+# In order to run the script, simply type `$ . ./bash_aliases.sh` from the root of the project.
 # (refreshing the current terminal session could be required)
 
 # Executes the docker compose script to wake up the postgres container

--- a/canyon_connection/Cargo.toml
+++ b/canyon_connection/Cargo.toml
@@ -16,7 +16,7 @@ tokio-postgres = { version = "0.7.2", features = ["with-chrono-0_4"] }
 futures = "0.3.25"
 indexmap = "1.9.1"
 
-tiberius = { version = "0.11.3", features = ["tds73", "chrono"] }
+tiberius = { version = "0.12.1", features = ["tds73", "chrono", "winauth", "integrated-auth-gssapi"] }
 async-std = { version = "1.12.0" }
 
 lazy_static = "1.4.0"

--- a/canyon_connection/Cargo.toml
+++ b/canyon_connection/Cargo.toml
@@ -16,10 +16,14 @@ tokio-postgres = { version = "0.7.2", features = ["with-chrono-0_4"] }
 futures = "0.3.25"
 indexmap = "1.9.1"
 
-tiberius = { version = "0.12.1", features = ["tds73", "chrono", "winauth", "integrated-auth-gssapi"] }
+tiberius = { version = "0.12.1", features = ["tds73", "chrono", "integrated-auth-gssapi"] }
 async-std = { version = "1.12.0" }
 
 lazy_static = "1.4.0"
 
 serde = { version = "1.0.138", features = ["derive"] }
 toml = "0.7.3"
+
+[target.'cfg(windows)'.dependencies.tiberius]
+version = "0.12.1"
+features = ["tds73", "chrono", "winauth"]

--- a/canyon_connection/Cargo.toml
+++ b/canyon_connection/Cargo.toml
@@ -24,6 +24,3 @@ lazy_static = "1.4.0"
 serde = { version = "1.0.138", features = ["derive"] }
 toml = "0.7.3"
 
-[target.'cfg(windows)'.dependencies.tiberius]
-version = "0.12.1"
-features = ["tds73", "chrono", "winauth"]

--- a/canyon_connection/Cargo.toml
+++ b/canyon_connection/Cargo.toml
@@ -24,3 +24,6 @@ lazy_static = "1.4.0"
 serde = { version = "1.0.138", features = ["derive"] }
 toml = "0.7.3"
 
+[features]
+mssql-integrated-auth = []
+

--- a/canyon_connection/Cargo.toml
+++ b/canyon_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canyon_connection"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 documentation = "https://zerodaycode.github.io/canyon-book/"
 homepage = "https://github.com/zerodaycode/Canyon-SQL"

--- a/canyon_connection/Cargo.toml
+++ b/canyon_connection/Cargo.toml
@@ -22,4 +22,4 @@ async-std = { version = "1.12.0" }
 lazy_static = "1.4.0"
 
 serde = { version = "1.0.138", features = ["derive"] }
-toml = "0.5.9"
+toml = "0.7.3"

--- a/canyon_connection/src/canyon_database_connector.rs
+++ b/canyon_connection/src/canyon_database_connector.rs
@@ -41,7 +41,7 @@ unsafe impl Sync for DatabaseConnection {}
 
 impl DatabaseConnection {
     pub async fn new(
-        datasource: &DatasourceConfig<'_>,
+        datasource: &DatasourceConfig,
     ) -> Result<DatabaseConnection, Box<(dyn std::error::Error + Send + Sync + 'static)>> {
         match datasource.db_type {
             DatabaseType::PostgreSql => {
@@ -72,14 +72,14 @@ impl DatabaseConnection {
             DatabaseType::SqlServer => {
                 let mut config = Config::new();
 
-                config.host(datasource.properties.host);
+                config.host(&datasource.properties.host);
                 config.port(datasource.properties.port.unwrap_or_default());
-                config.database(datasource.properties.db_name);
+                config.database(&datasource.properties.db_name);
 
                 // Using SQL Server authentication.
                 config.authentication(AuthMethod::sql_server(
-                    datasource.properties.username,
-                    datasource.properties.password,
+                    &datasource.properties.username,
+                    &datasource.properties.password,
                 ));
 
                 // on production, it is not a good idea to do this. We should upgrade

--- a/canyon_connection/src/canyon_database_connector.rs
+++ b/canyon_connection/src/canyon_database_connector.rs
@@ -95,6 +95,7 @@ impl DatabaseConnection {
                         crate::datasources::SqlServerAuth::Basic { username, password } => {
                             AuthMethod::sql_server(username, password)
                         }
+                        #[cfg(feature = "mssql-integrated-auth")]
                         crate::datasources::SqlServerAuth::Integrated => AuthMethod::Integrated,
                     },
                 });

--- a/canyon_connection/src/canyon_database_connector.rs
+++ b/canyon_connection/src/canyon_database_connector.rs
@@ -43,7 +43,7 @@ impl DatabaseConnection {
     pub async fn new(
         datasource: &DatasourceConfig,
     ) -> Result<DatabaseConnection, Box<(dyn std::error::Error + Send + Sync + 'static)>> {
-        match datasource.db_type {
+        match datasource.get_db_type() {
             DatabaseType::PostgreSql => {
                 let (username, password) = match &datasource.auth {
                     crate::datasources::Auth::Postgres(postgres_auth) => match postgres_auth {
@@ -152,8 +152,8 @@ mod database_connection_handler {
     const CONFIG_FILE_MOCK_ALT: &str = r#"
         [canyon_sql]
         datasources = [
-            {name = 'PostgresDS', db_type = 'postgresql', auth = { postgresql = { basic = { username = "postgres", password = "postgres" } } }, properties.host = 'localhost', properties.db_name = 'triforce', properties.migrations='enabled' },
-            {name = 'SqlServerDS', db_type = 'sqlserver', auth = { sqlserver = { basic = { username = "sa", password = "SqlServer-10" } } }, properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2', properties.migrations='disabled' }
+            {name = 'PostgresDS', auth = { postgresql = { basic = { username = "postgres", password = "postgres" } } }, properties.host = 'localhost', properties.db_name = 'triforce', properties.migrations='enabled' },
+            {name = 'SqlServerDS', auth = { sqlserver = { basic = { username = "sa", password = "SqlServer-10" } } }, properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2', properties.migrations='disabled' }
         ]
     "#;
 
@@ -164,11 +164,11 @@ mod database_connection_handler {
             .expect("A failure happened retrieving the [canyon_sql] section");
 
         assert_eq!(
-            config.canyon_sql.datasources[0].db_type,
+            config.canyon_sql.datasources[0].get_db_type(),
             DatabaseType::PostgreSql
         );
         assert_eq!(
-            config.canyon_sql.datasources[1].db_type,
+            config.canyon_sql.datasources[1].get_db_type(),
             DatabaseType::SqlServer
         );
     }

--- a/canyon_connection/src/datasources.rs
+++ b/canyon_connection/src/datasources.rs
@@ -95,6 +95,7 @@ pub enum PostgresAuth {
 pub enum SqlServerAuth {
     #[serde(alias = "Basic", alias = "basic")]
     Basic { username: String, password: String },
+    #[cfg(feature = "mssql-integrated-auth")]
     #[serde(alias = "Integrated", alias = "integrated")]
     Integrated,
 }

--- a/canyon_connection/src/datasources.rs
+++ b/canyon_connection/src/datasources.rs
@@ -8,8 +8,8 @@ fn load_ds_config_from_array() {
     const CONFIG_FILE_MOCK_ALT: &str = r#"
         [canyon_sql]
         datasources = [
-            {name = 'PostgresDS', properties.db_type = 'postgresql', properties.username = 'username', properties.password = 'random_pass', properties.host = 'localhost', properties.db_name = 'triforce', properties.migrations = 'enabled'},
-            {name = 'SqlServerDS', properties.db_type = 'sqlserver', properties.username = 'username2', properties.password = 'random_pass2', properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2'}
+            {name = 'PostgresDS', db_type = 'postgresql', properties.username = 'username', properties.password = 'random_pass', properties.host = 'localhost', properties.db_name = 'triforce', properties.migrations = 'enabled'},
+            {name = 'SqlServerDS', db_type = 'sqlserver', properties.username = 'username2', properties.password = 'random_pass2', properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2'}
         ]
     "#;
 
@@ -20,7 +20,7 @@ fn load_ds_config_from_array() {
     let ds_1 = &config.canyon_sql.datasources[1];
 
     assert_eq!(ds_0.name, "PostgresDS");
-    assert_eq!(ds_0.properties.db_type, DatabaseType::PostgreSql);
+    assert_eq!(ds_0.db_type, DatabaseType::PostgreSql);
     assert_eq!(ds_0.properties.username, "username");
     assert_eq!(ds_0.properties.password, "random_pass");
     assert_eq!(ds_0.properties.host, "localhost");
@@ -29,7 +29,7 @@ fn load_ds_config_from_array() {
     assert_eq!(ds_0.properties.migrations, Some(Migrations::Enabled));
 
     assert_eq!(ds_1.name, "SqlServerDS");
-    assert_eq!(ds_1.properties.db_type, DatabaseType::SqlServer);
+    assert_eq!(ds_1.db_type, DatabaseType::SqlServer);
     assert_eq!(ds_1.properties.username, "username2");
     assert_eq!(ds_1.properties.password, "random_pass2");
     assert_eq!(ds_1.properties.host, "192.168.0.250.1");
@@ -53,12 +53,13 @@ pub struct Datasources<'a> {
 pub struct DatasourceConfig<'a> {
     #[serde(borrow)]
     pub name: &'a str,
+    pub db_type: DatabaseType,
     pub properties: DatasourceProperties<'a>,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]
 pub struct DatasourceProperties<'a> {
-    pub db_type: DatabaseType,
+    
     pub username: &'a str,
     pub password: &'a str,
     pub host: &'a str,

--- a/canyon_connection/src/datasources.rs
+++ b/canyon_connection/src/datasources.rs
@@ -9,7 +9,8 @@ fn load_ds_config_from_array() {
     [canyon_sql]
     datasources = [
         {name = 'PostgresDS', auth = { postgresql = { basic = { username = "postgres", password = "postgres" } } }, properties.host = 'localhost', properties.db_name = 'triforce', properties.migrations='enabled' },
-        {name = 'SqlServerDS', auth = { sqlserver = { basic = { username = "sa", password = "SqlServer-10" } } }, properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2', properties.migrations='disabled' }
+        {name = 'SqlServerDS', auth = { sqlserver = { basic = { username = "sa", password = "SqlServer-10" } } }, properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2', properties.migrations='disabled' },
+        {name = 'SqlServerDS', auth = { sqlserver = { integrated = {} } }, properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2', properties.migrations='disabled' }
     ]
     "#;
 
@@ -18,6 +19,7 @@ fn load_ds_config_from_array() {
 
     let ds_0 = &config.canyon_sql.datasources[0];
     let ds_1 = &config.canyon_sql.datasources[1];
+    let ds_2 = &config.canyon_sql.datasources[2];
 
     assert_eq!(ds_0.name, "PostgresDS");
     assert_eq!(ds_0.get_db_type(), DatabaseType::PostgreSql);
@@ -46,6 +48,8 @@ fn load_ds_config_from_array() {
     assert_eq!(ds_1.properties.port, Some(3340));
     assert_eq!(ds_1.properties.db_name, "triforce2");
     assert_eq!(ds_1.properties.migrations, Some(Migrations::Disabled));
+
+    assert_eq!(ds_2.auth, Auth::SqlServer(SqlServerAuth::Integrated))
 }
 ///
 #[derive(Deserialize, Debug, Clone)]

--- a/canyon_connection/src/datasources.rs
+++ b/canyon_connection/src/datasources.rs
@@ -21,8 +21,8 @@ fn load_ds_config_from_array() {
 
     assert_eq!(ds_0.name, "PostgresDS");
     assert_eq!(ds_0.db_type, DatabaseType::PostgreSql);
-    assert_eq!(ds_0.properties.username, "username");
-    assert_eq!(ds_0.properties.password, "random_pass");
+    // assert_eq!(ds_0.properties.username, "username");
+    // assert_eq!(ds_0.properties.password, "random_pass");
     assert_eq!(ds_0.properties.host, "localhost");
     assert_eq!(ds_0.properties.port, None);
     assert_eq!(ds_0.properties.db_name, "triforce");
@@ -30,8 +30,7 @@ fn load_ds_config_from_array() {
 
     assert_eq!(ds_1.name, "SqlServerDS");
     assert_eq!(ds_1.db_type, DatabaseType::SqlServer);
-    assert_eq!(ds_1.properties.username, "username2");
-    assert_eq!(ds_1.properties.password, "random_pass2");
+    // assert_eq!(ds_1.auth, Some(Auth::Basic("username2".to_string(), "random_pass2".to_string())));
     assert_eq!(ds_1.properties.host, "192.168.0.250.1");
     assert_eq!(ds_1.properties.port, Some(3340));
     assert_eq!(ds_1.properties.db_name, "triforce2");
@@ -51,13 +50,20 @@ pub struct Datasources {
 pub struct DatasourceConfig {
     pub name: String,
     pub db_type: DatabaseType,
+    pub auth: Option<Auth>,
     pub properties: DatasourceProperties,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub enum Auth {
+    #[serde(alias = "Basic", alias = "basic")]
+    Basic {username: String, password: String},
+    #[serde(alias = "Integrated", alias = "integrated")]
+    Integrated,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct DatasourceProperties {
-    pub username: String,
-    pub password: String,
     pub host: String,
     pub port: Option<u16>,
     pub db_name: String,

--- a/canyon_connection/src/datasources.rs
+++ b/canyon_connection/src/datasources.rs
@@ -8,8 +8,8 @@ fn load_ds_config_from_array() {
     const CONFIG_FILE_MOCK_ALT: &str = r#"
     [canyon_sql]
     datasources = [
-        {name = 'PostgresDS', db_type = 'postgresql', auth = { postgresql = { basic = { username = "postgres", password = "postgres" } } }, properties.host = 'localhost', properties.db_name = 'triforce', properties.migrations='enabled' },
-        {name = 'SqlServerDS', db_type = 'sqlserver', auth = { sqlserver = { basic = { username = "sa", password = "SqlServer-10" } } }, properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2', properties.migrations='disabled' }
+        {name = 'PostgresDS', auth = { postgresql = { basic = { username = "postgres", password = "postgres" } } }, properties.host = 'localhost', properties.db_name = 'triforce', properties.migrations='enabled' },
+        {name = 'SqlServerDS', auth = { sqlserver = { basic = { username = "sa", password = "SqlServer-10" } } }, properties.host = '192.168.0.250.1', properties.port = 3340, properties.db_name = 'triforce2', properties.migrations='disabled' }
     ]
     "#;
 
@@ -20,7 +20,7 @@ fn load_ds_config_from_array() {
     let ds_1 = &config.canyon_sql.datasources[1];
 
     assert_eq!(ds_0.name, "PostgresDS");
-    assert_eq!(ds_0.db_type, DatabaseType::PostgreSql);
+    assert_eq!(ds_0.get_db_type(), DatabaseType::PostgreSql);
     assert_eq!(
         ds_0.auth,
         Auth::Postgres(PostgresAuth::Basic {
@@ -34,7 +34,7 @@ fn load_ds_config_from_array() {
     assert_eq!(ds_0.properties.migrations, Some(Migrations::Enabled));
 
     assert_eq!(ds_1.name, "SqlServerDS");
-    assert_eq!(ds_1.db_type, DatabaseType::SqlServer);
+    assert_eq!(ds_1.get_db_type(), DatabaseType::SqlServer);
     assert_eq!(
         ds_1.auth,
         Auth::SqlServer(SqlServerAuth::Basic {
@@ -60,9 +60,17 @@ pub struct Datasources {
 #[derive(Deserialize, Debug, Clone)]
 pub struct DatasourceConfig {
     pub name: String,
-    pub db_type: DatabaseType,
     pub auth: Auth,
     pub properties: DatasourceProperties,
+}
+
+impl DatasourceConfig {
+    pub fn get_db_type(&self) -> DatabaseType {
+        match self.auth {
+            Auth::Postgres(_) => DatabaseType::PostgreSql,
+            Auth::SqlServer(_) => DatabaseType::SqlServer,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]

--- a/canyon_connection/src/datasources.rs
+++ b/canyon_connection/src/datasources.rs
@@ -39,32 +39,28 @@ fn load_ds_config_from_array() {
 }
 ///
 #[derive(Deserialize, Debug, Clone)]
-pub struct CanyonSqlConfig<'a> {
-    #[serde(borrow)]
-    pub canyon_sql: Datasources<'a>,
+pub struct CanyonSqlConfig {
+    pub canyon_sql: Datasources,
 }
 #[derive(Deserialize, Debug, Clone)]
-pub struct Datasources<'a> {
-    #[serde(borrow)]
-    pub datasources: Vec<DatasourceConfig<'a>>,
+pub struct Datasources {
+    pub datasources: Vec<DatasourceConfig>,
 }
 
-#[derive(Deserialize, Debug, Clone, Copy)]
-pub struct DatasourceConfig<'a> {
-    #[serde(borrow)]
-    pub name: &'a str,
+#[derive(Deserialize, Debug, Clone)]
+pub struct DatasourceConfig {
+    pub name: String,
     pub db_type: DatabaseType,
-    pub properties: DatasourceProperties<'a>,
+    pub properties: DatasourceProperties,
 }
 
-#[derive(Deserialize, Debug, Clone, Copy)]
-pub struct DatasourceProperties<'a> {
-    
-    pub username: &'a str,
-    pub password: &'a str,
-    pub host: &'a str,
+#[derive(Deserialize, Debug, Clone)]
+pub struct DatasourceProperties {
+    pub username: String,
+    pub password: String,
+    pub host: String,
     pub port: Option<u16>,
-    pub db_name: &'a str,
+    pub db_name: String,
     pub migrations: Option<Migrations>,
 }
 

--- a/canyon_connection/src/lib.rs
+++ b/canyon_connection/src/lib.rs
@@ -50,7 +50,7 @@ pub async fn init_connections_cache() {
     for datasource in DATASOURCES.iter() {
         CACHED_DATABASE_CONN.lock().await.insert(
             datasource.name,
-            DatabaseConnection::new(&datasource.properties)
+            DatabaseConnection::new(&datasource)
                 .await
                 .unwrap_or_else(|_| {
                     panic!(

--- a/canyon_connection/src/lib.rs
+++ b/canyon_connection/src/lib.rs
@@ -40,10 +40,10 @@ lazy_static! {
 /// in the configuration file.
 ///
 /// This avoids Canyon to create a new connection to the database on every query, potentially avoiding bottlenecks
-/// derivated from the instantiation of that new conn every time.
+/// coming from the instantiation of that new conn every time.
 ///
 /// Note: We noticed with the integration tests that the [`tokio_postgres`] crate (PostgreSQL) is able to work in an async environment
-/// with a new connection per query without no problem, but the [`tiberius`] crate (MSSQL) sufferes a lot when it has continuous
+/// with a new connection per query without no problem, but the [`tiberius`] crate (MSSQL) suffers a lot when it has continuous
 /// statements with multiple queries, like and insert followed by a find by id to check if the insert query has done its
 /// job done.
 pub async fn init_connections_cache() {

--- a/canyon_connection/src/lib.rs
+++ b/canyon_connection/src/lib.rs
@@ -50,7 +50,7 @@ pub async fn init_connections_cache() {
     for datasource in DATASOURCES.iter() {
         CACHED_DATABASE_CONN.lock().await.insert(
             &datasource.name,
-            DatabaseConnection::new(&datasource)
+            DatabaseConnection::new(datasource)
                 .await
                 .unwrap_or_else(|_| {
                     panic!(

--- a/canyon_connection/src/lib.rs
+++ b/canyon_connection/src/lib.rs
@@ -26,10 +26,10 @@ lazy_static! {
 
     static ref RAW_CONFIG_FILE: String = fs::read_to_string(CONFIG_FILE_IDENTIFIER)
         .expect("Error opening or reading the Canyon configuration file");
-    static ref CONFIG_FILE: CanyonSqlConfig<'static> = toml::from_str(RAW_CONFIG_FILE.as_str())
+    static ref CONFIG_FILE: CanyonSqlConfig = toml::from_str(RAW_CONFIG_FILE.as_str())
         .expect("Error generating the configuration for Canyon-SQL");
 
-    pub static ref DATASOURCES: Vec<DatasourceConfig<'static>> =
+    pub static ref DATASOURCES: Vec<DatasourceConfig> =
         CONFIG_FILE.canyon_sql.datasources.clone();
 
     pub static ref CACHED_DATABASE_CONN: Mutex<IndexMap<&'static str, DatabaseConnection>> =
@@ -49,7 +49,7 @@ lazy_static! {
 pub async fn init_connections_cache() {
     for datasource in DATASOURCES.iter() {
         CACHED_DATABASE_CONN.lock().await.insert(
-            datasource.name,
+            &datasource.name,
             DatabaseConnection::new(&datasource)
                 .await
                 .unwrap_or_else(|_| {

--- a/canyon_crud/Cargo.toml
+++ b/canyon_crud/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canyon_crud"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 documentation = "https://zerodaycode.github.io/canyon-book/"
 homepage = "https://github.com/zerodaycode/Canyon-SQL"
@@ -12,4 +12,4 @@ description = "A Rust ORM and QueryBuilder"
 chrono = { version = "0.4", features = ["serde"] }
 async-trait = { version = "0.1.50" }
 
-canyon_connection = { version = "0.1.2", path = "../canyon_connection" }
+canyon_connection = { version = "0.2.0", path = "../canyon_connection" }

--- a/canyon_crud/src/crud.rs
+++ b/canyon_crud/src/crud.rs
@@ -36,9 +36,11 @@ pub trait Transaction<T> {
         let database_conn = if datasource_name.is_empty() {
             guarded_cache
             .get_mut(
-                DATASOURCES.get(0)
+                DATASOURCES
+                    .get(0)
                     .expect("We didn't found any valid datasource configuration. Check your `canyon.toml` file")
                     .name
+                    .as_str()
             ).unwrap_or_else(|| panic!("No default datasource found. Check your `canyon.toml` file"))
         } else {
             guarded_cache.get_mut(datasource_name)
@@ -227,7 +229,7 @@ mod sqlserver_query_launcher {
             .query(
                 db_conn
                     .sqlserver_connection()
-                    .expect("Error quering the MSSQL database")
+                    .expect("Error querying the MSSQL database")
                     .client
             ).await?
             .into_results()

--- a/canyon_crud/src/crud.rs
+++ b/canyon_crud/src/crud.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 
 use async_trait::async_trait;
-use canyon_connection::canyon_database_connector::DatabaseType;
-use canyon_connection::CACHED_DATABASE_CONN;
+use canyon_connection::canyon_database_connector::DatabaseConnection;
+use canyon_connection::{CACHED_DATABASE_CONN, DATASOURCES};
 
 use crate::bounds::QueryParameter;
 use crate::mapper::RowMapper;
@@ -32,22 +32,24 @@ pub trait Transaction<T> {
         S: AsRef<str> + Display + Sync + Send + 'a,
         Z: AsRef<[&'a dyn QueryParameter<'a>]> + Sync + Send + 'a,
     {
-        let guarded_cache = CACHED_DATABASE_CONN.lock().await;
+        let mut guarded_cache = CACHED_DATABASE_CONN.lock().await;
 
         let database_conn = if datasource_name.is_empty() {
             guarded_cache
-                .values()
-                .next()
-                .expect("No default datasource found. Check your `canyon.toml` file")
+            .get_mut(
+                DATASOURCES.get(0)
+                    .expect("We didn't found any valid datasource configuration. Check your `canyon.toml` file")
+                    .name
+            ).unwrap_or_else(|| panic!("No default datasource found. Check your `canyon.toml` file"))
         } else {
-            guarded_cache.get(datasource_name)
+            guarded_cache.get_mut(datasource_name)
                 .unwrap_or_else(||
                     panic!("Canyon couldn't find a datasource in the pool with the argument provided: {datasource_name}"
                 ))
         };
 
-        match database_conn.database_type {
-            DatabaseType::PostgreSql => {
+        match database_conn {
+            DatabaseConnection::Postgres(_) => {
                 postgres_query_launcher::launch::<T>(
                     database_conn,
                     stmt.to_string(),
@@ -55,7 +57,7 @@ pub trait Transaction<T> {
                 )
                 .await
             }
-            DatabaseType::SqlServer => {
+            DatabaseConnection::SqlServer(_) => {
                 sqlserver_query_launcher::launch::<T, Z>(
                     database_conn,
                     &mut stmt.to_string(),
@@ -174,8 +176,7 @@ mod postgres_query_launcher {
 
         Ok(DatabaseResult::new_postgresql(
             db_conn
-                .postgres_connection
-                .as_ref()
+                .postgres_connection()
                 .unwrap()
                 .client
                 .query(&stmt, m_params.as_slice())
@@ -185,8 +186,6 @@ mod postgres_query_launcher {
 }
 
 mod sqlserver_query_launcher {
-    use std::mem::transmute;
-
     use canyon_connection::tiberius::Row;
 
     use crate::{
@@ -196,7 +195,7 @@ mod sqlserver_query_launcher {
     };
 
     pub async fn launch<'a, T, Z>(
-        db_conn: &&mut DatabaseConnection,
+        db_conn: &mut DatabaseConnection,
         stmt: &mut String,
         params: Z,
     ) -> Result<DatabaseResult<T>, Box<(dyn std::error::Error + Send + Sync + 'static)>>
@@ -208,10 +207,8 @@ mod sqlserver_query_launcher {
             let c = stmt.clone();
             let temp = c
                 .split_once("RETURNING")
-                .expect("An error happened generating an INSERT statement for a SQL SERVER client");
-            let temp2 = temp.0.split_once("VALUES").expect(
-                "An error happened generating an INSERT statement for a SQL SERVER client [1]",
-            );
+                .unwrap();
+            let temp2 = temp.0.split_once("VALUES").unwrap();
 
             *stmt = format!(
                 "{} OUTPUT inserted.{} VALUES {}",
@@ -227,16 +224,13 @@ mod sqlserver_query_launcher {
             .iter()
             .for_each(|param| mssql_query.bind(*param));
 
-        #[allow(mutable_transmutes)]
         let _results: Vec<Row> = mssql_query
             .query(
-                unsafe { transmute::<&DatabaseConnection, &mut DatabaseConnection>(db_conn) }
-                    .sqlserver_connection
-                    .as_mut()
-                    .expect("Error querying the MSSQL database")
-                    .client,
-            )
-            .await?
+                db_conn
+                    .sqlserver_connection()
+                    .expect("Error quering the MSSQL database")
+                    .client
+            ).await?
             .into_results()
             .await?
             .into_iter()

--- a/canyon_crud/src/crud.rs
+++ b/canyon_crud/src/crud.rs
@@ -206,9 +206,7 @@ mod sqlserver_query_launcher {
         // Re-generate de insert statement to adequate it to the SQL SERVER syntax to retrieve the PK value(s) after insert
         if stmt.contains("RETURNING") {
             let c = stmt.clone();
-            let temp = c
-                .split_once("RETURNING")
-                .unwrap();
+            let temp = c.split_once("RETURNING").unwrap();
             let temp2 = temp.0.split_once("VALUES").unwrap();
 
             *stmt = format!(
@@ -230,8 +228,9 @@ mod sqlserver_query_launcher {
                 db_conn
                     .sqlserver_connection()
                     .expect("Error querying the MSSQL database")
-                    .client
-            ).await?
+                    .client,
+            )
+            .await?
             .into_results()
             .await?
             .into_iter()

--- a/canyon_crud/src/crud.rs
+++ b/canyon_crud/src/crud.rs
@@ -18,7 +18,6 @@ use crate::result::DatabaseResult;
 /// the result of the query and, if the user desires,
 /// automatically map it to an struct.
 #[async_trait]
-#[allow(clippy::question_mark)]
 pub trait Transaction<T> {
     /// Performs a query against the targeted database by the selected datasource.
     ///

--- a/canyon_macros/Cargo.toml
+++ b/canyon_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canyon_macros"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 documentation = "https://zerodaycode.github.io/canyon-book/"
 homepage = "https://github.com/zerodaycode/Canyon-SQL"
@@ -18,6 +18,6 @@ proc-macro2 = "1.0.27"
 futures = "0.3.21"
 tokio = { version = "1.9.0", features = ["full"] }
 
-canyon_observer = { version = "0.1.2", path = "../canyon_observer" }
-canyon_crud = { version = "0.1.2", path = "../canyon_crud" }
-canyon_connection = { version = "0.1.2", path = "../canyon_connection" }
+canyon_observer = { version = "0.2.0", path = "../canyon_observer" }
+canyon_crud = { version = "0.2.0", path = "../canyon_crud" }
+canyon_connection = { version = "0.2.0", path = "../canyon_connection" }

--- a/canyon_macros/Cargo.toml
+++ b/canyon_macros/Cargo.toml
@@ -12,7 +12,7 @@ description = "A Rust ORM and QueryBuilder"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.86", features = ["full"] }
+syn = { version = "1.0.109", features = ["full"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.27"
 futures = "0.3.21"

--- a/canyon_macros/src/query_operations/select.rs
+++ b/canyon_macros/src/query_operations/select.rs
@@ -30,7 +30,7 @@ pub fn generate_find_all_unchecked_tokens(
             .get_entities::<#ty>()
         }
 
-        /// Performns a `SELECT * FROM table_name`, where `table_name` it's
+        /// Performs a `SELECT * FROM table_name`, where `table_name` it's
         /// the name of your entity but converted to the corresponding
         /// database convention. P.ej. PostgreSQL prefers table names declared
         /// with snake_case identifiers.

--- a/canyon_macros/src/utils/helpers.rs
+++ b/canyon_macros/src/utils/helpers.rs
@@ -103,6 +103,7 @@ pub fn _database_table_name_from_struct(ty: &Ident) -> String {
 
 /// Parses a syn::Identifier to create a defaulted snake case database table name
 #[test]
+#[cfg(not(target_env = "msvc"))]
 fn test_entity_database_name_defaulter() {
     assert_eq!(
         default_database_table_name_from_entity_name("League"),

--- a/canyon_observer/Cargo.toml
+++ b/canyon_observer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canyon_observer"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 documentation = "https://zerodaycode.github.io/canyon-book/"
 homepage = "https://github.com/zerodaycode/Canyon-SQL"
@@ -23,5 +23,5 @@ quote = "1.0.9"
 partialdebug = "0.2.0"
 
 # Internal dependencies
-canyon_crud = { version = "0.1.2", path = "../canyon_crud" }
-canyon_connection = { version = "0.1.2", path = "../canyon_connection" }
+canyon_crud = { version = "0.2.0", path = "../canyon_crud" }
+canyon_connection = { version = "0.2.0", path = "../canyon_connection" }

--- a/canyon_observer/src/lib.rs
+++ b/canyon_observer/src/lib.rs
@@ -23,8 +23,29 @@ use std::{collections::HashMap, sync::Mutex};
 pub static CANYON_REGISTER_ENTITIES: Mutex<Vec<CanyonRegisterEntity<'static>>> =
     Mutex::new(Vec::new());
 lazy_static! {
-    pub static ref QUERIES_TO_EXECUTE: Mutex<HashMap<&'static str, Vec<String>>> =
+    pub static ref QUERIES_TO_EXECUTE: Mutex<HashMap<String, Vec<String>>> =
         Mutex::new(HashMap::new());
-    pub static ref CM_QUERIES_TO_EXECUTE: Mutex<HashMap<&'static str, Vec<String>>> =
+    pub static ref CM_QUERIES_TO_EXECUTE: Mutex<HashMap<String, Vec<String>>> =
         Mutex::new(HashMap::new());
+}
+
+/// Stores a newly generated SQL statement from the migrations into the register
+pub fn save_migrations_query_to_execute(stmt: String, ds_name: &str) {
+    if QUERIES_TO_EXECUTE
+        .lock()
+        .unwrap()
+        .contains_key(ds_name)
+    {
+        QUERIES_TO_EXECUTE
+            .lock()
+            .unwrap()
+            .get_mut(ds_name)
+            .unwrap()
+            .push(stmt);
+    } else {
+        QUERIES_TO_EXECUTE
+            .lock()
+            .unwrap()
+            .insert(ds_name.to_owned(), vec![stmt]);
+    }
 }

--- a/canyon_observer/src/lib.rs
+++ b/canyon_observer/src/lib.rs
@@ -31,11 +31,7 @@ lazy_static! {
 
 /// Stores a newly generated SQL statement from the migrations into the register
 pub fn save_migrations_query_to_execute(stmt: String, ds_name: &str) {
-    if QUERIES_TO_EXECUTE
-        .lock()
-        .unwrap()
-        .contains_key(ds_name)
-    {
+    if QUERIES_TO_EXECUTE.lock().unwrap().contains_key(ds_name) {
         QUERIES_TO_EXECUTE
             .lock()
             .unwrap()

--- a/canyon_observer/src/migrations/handler.rs
+++ b/canyon_observer/src/migrations/handler.rs
@@ -51,7 +51,7 @@ impl Migrations {
             let canyon_memory = CanyonMemory::remember(datasource, &canyon_entities).await;
 
             // Tracked entities that must be migrated whenever Canyon starts
-            let schema_status = Self::fetch_database(&datasource.name, datasource.db_type).await;
+            let schema_status = Self::fetch_database(&datasource.name, datasource.get_db_type()).await;
             let database_tables_schema_info = Self::map_rows(schema_status);
 
             // We filter the tables from the schema that aren't Canyon entities

--- a/canyon_observer/src/migrations/handler.rs
+++ b/canyon_observer/src/migrations/handler.rs
@@ -52,7 +52,7 @@ impl Migrations {
 
             // Tracked entities that must be migrated whenever Canyon starts
             let schema_status =
-                Self::fetch_database(datasource.name, datasource.properties.db_type).await;
+                Self::fetch_database(datasource.name, datasource.db_type).await;
             let database_tables_schema_info = Self::map_rows(schema_status);
 
             // We filter the tables from the schema that aren't Canyon entities

--- a/canyon_observer/src/migrations/handler.rs
+++ b/canyon_observer/src/migrations/handler.rs
@@ -51,7 +51,8 @@ impl Migrations {
             let canyon_memory = CanyonMemory::remember(datasource, &canyon_entities).await;
 
             // Tracked entities that must be migrated whenever Canyon starts
-            let schema_status = Self::fetch_database(&datasource.name, datasource.get_db_type()).await;
+            let schema_status =
+                Self::fetch_database(&datasource.name, datasource.get_db_type()).await;
             let database_tables_schema_info = Self::map_rows(schema_status);
 
             // We filter the tables from the schema that aren't Canyon entities

--- a/canyon_observer/src/migrations/handler.rs
+++ b/canyon_observer/src/migrations/handler.rs
@@ -51,8 +51,7 @@ impl Migrations {
             let canyon_memory = CanyonMemory::remember(datasource, &canyon_entities).await;
 
             // Tracked entities that must be migrated whenever Canyon starts
-            let schema_status =
-                Self::fetch_database(&datasource.name, datasource.db_type).await;
+            let schema_status = Self::fetch_database(&datasource.name, datasource.db_type).await;
             let database_tables_schema_info = Self::map_rows(schema_status);
 
             // We filter the tables from the schema that aren't Canyon entities

--- a/canyon_observer/src/migrations/handler.rs
+++ b/canyon_observer/src/migrations/handler.rs
@@ -52,7 +52,7 @@ impl Migrations {
 
             // Tracked entities that must be migrated whenever Canyon starts
             let schema_status =
-                Self::fetch_database(datasource.name, datasource.db_type).await;
+                Self::fetch_database(&datasource.name, datasource.db_type).await;
             let database_tables_schema_info = Self::map_rows(schema_status);
 
             // We filter the tables from the schema that aren't Canyon entities

--- a/canyon_observer/src/migrations/memory.rs
+++ b/canyon_observer/src/migrations/memory.rs
@@ -64,7 +64,7 @@ impl CanyonMemory {
         canyon_entities: &[CanyonRegisterEntity<'_>],
     ) -> Self {
         // Creates the memory table if not exists
-        Self::create_memory(datasource.name, &datasource.properties.db_type).await;
+        Self::create_memory(datasource.name, &datasource.db_type).await;
 
         // Retrieve the last status data from the `canyon_memory` table
         let res = Self::query("SELECT * FROM canyon_memory", [], datasource.name)

--- a/canyon_observer/src/migrations/memory.rs
+++ b/canyon_observer/src/migrations/memory.rs
@@ -64,7 +64,7 @@ impl CanyonMemory {
         canyon_entities: &[CanyonRegisterEntity<'_>],
     ) -> Self {
         // Creates the memory table if not exists
-        Self::create_memory(&datasource.name, &datasource.db_type).await;
+        Self::create_memory(&datasource.name, &datasource.get_db_type()).await;
 
         // Retrieve the last status data from the `canyon_memory` table
         let res = Self::query("SELECT * FROM canyon_memory", [], &datasource.name)

--- a/canyon_observer/src/migrations/memory.rs
+++ b/canyon_observer/src/migrations/memory.rs
@@ -60,14 +60,14 @@ impl CanyonMemory {
     #[cfg(not(cargo_check))]
     #[allow(clippy::nonminimal_bool)]
     pub async fn remember(
-        datasource: &DatasourceConfig<'static>,
+        datasource: &DatasourceConfig,
         canyon_entities: &[CanyonRegisterEntity<'_>],
     ) -> Self {
         // Creates the memory table if not exists
-        Self::create_memory(datasource.name, &datasource.db_type).await;
+        Self::create_memory(&datasource.name, &datasource.db_type).await;
 
         // Retrieve the last status data from the `canyon_memory` table
-        let res = Self::query("SELECT * FROM canyon_memory", [], datasource.name)
+        let res = Self::query("SELECT * FROM canyon_memory", [], &datasource.name)
             .await
             .expect("Error querying Canyon Memory");
         let mem_results = res.as_canyon_rows();
@@ -112,7 +112,7 @@ impl CanyonMemory {
                                 WHERE id = {}",
                         _struct.filepath, _struct.struct_name, _struct.declared_table_name, old.id
                     );
-                    save_canyon_memory_query(stmt, datasource.name);
+                    save_canyon_memory_query(stmt, &datasource.name);
 
                     // if the updated element is the struct name, we add it to the table_rename Hashmap
                     let rename_table = old.declared_table_name != _struct.declared_table_name;
@@ -132,7 +132,7 @@ impl CanyonMemory {
                         VALUES ('{}', '{}', '{}')",
                     _struct.filepath, _struct.struct_name, _struct.declared_table_name
                 );
-                save_canyon_memory_query(stmt, datasource.name)
+                save_canyon_memory_query(stmt, &datasource.name)
             }
         }
 
@@ -149,7 +149,7 @@ impl CanyonMemory {
                         "DELETE FROM canyon_memory WHERE struct_name = '{}'",
                         db_row.struct_name
                     ),
-                    datasource.name,
+                    &datasource.name,
                 );
             }
         }
@@ -230,7 +230,7 @@ impl CanyonMemory {
     }
 }
 
-fn save_canyon_memory_query(stmt: String, ds_name: &'static str) {
+fn save_canyon_memory_query(stmt: String, ds_name: &str) {
     use crate::CM_QUERIES_TO_EXECUTE;
 
     if CM_QUERIES_TO_EXECUTE.lock().unwrap().contains_key(ds_name) {
@@ -244,7 +244,7 @@ fn save_canyon_memory_query(stmt: String, ds_name: &'static str) {
         CM_QUERIES_TO_EXECUTE
             .lock()
             .unwrap()
-            .insert(ds_name, vec![stmt]);
+            .insert(ds_name.to_owned(), vec![stmt]);
     }
 }
 

--- a/canyon_observer/src/migrations/processor.rs
+++ b/canyon_observer/src/migrations/processor.rs
@@ -35,7 +35,7 @@ impl MigrationsProcessor {
         datasource: &'_ DatasourceConfig,
     ) {
         // The database type formally represented in Canyon
-        let db_type = datasource.db_type;
+        let db_type = datasource.get_db_type();
         // For each entity (table) on the register (Rust structs)
         for canyon_register_entity in canyon_entities {
             let entity_name = canyon_register_entity.entity_db_table_name;
@@ -748,7 +748,7 @@ impl<T: Debug> Transaction<T> for TableOperation {}
 #[async_trait]
 impl DatabaseOperation for TableOperation {
     async fn generate_sql(&self, datasource: &DatasourceConfig) {
-        let db_type = datasource.db_type;
+        let db_type = datasource.get_db_type();
 
         let stmt = match self {
             TableOperation::CreateTable(table_name, table_fields) => {
@@ -888,7 +888,7 @@ impl Transaction<Self> for ColumnOperation {}
 #[async_trait]
 impl DatabaseOperation for ColumnOperation {
     async fn generate_sql(&self, datasource: &DatasourceConfig) {
-        let db_type = datasource.db_type;
+        let db_type = datasource.get_db_type();
 
         let stmt = match self {
             ColumnOperation::CreateColumn(table_name, entity_field) =>
@@ -980,7 +980,7 @@ impl Transaction<Self> for SequenceOperation {}
 #[async_trait]
 impl DatabaseOperation for SequenceOperation {
     async fn generate_sql(&self, datasource: &DatasourceConfig) {
-        let db_type = datasource.db_type;
+        let db_type = datasource.get_db_type();
 
         let stmt = match self {
             SequenceOperation::ModifySequence(table_name, entity_field) => {

--- a/canyon_observer/src/migrations/processor.rs
+++ b/canyon_observer/src/migrations/processor.rs
@@ -35,7 +35,7 @@ impl MigrationsProcessor {
         datasource: &'_ DatasourceConfig<'static>,
     ) {
         // The database type formally represented in Canyon
-        let db_type = datasource.properties.db_type;
+        let db_type = datasource.db_type;
         // For each entity (table) on the register (Rust structs)
         for canyon_register_entity in canyon_entities {
             let entity_name = canyon_register_entity.entity_db_table_name;
@@ -748,7 +748,7 @@ impl<T: Debug> Transaction<T> for TableOperation {}
 #[async_trait]
 impl DatabaseOperation for TableOperation {
     async fn generate_sql(&self, datasource: &DatasourceConfig<'static>) {
-        let db_type = datasource.properties.db_type;
+        let db_type = datasource.db_type;
 
         let stmt = match self {
             TableOperation::CreateTable(table_name, table_fields) => {
@@ -904,7 +904,7 @@ impl Transaction<Self> for ColumnOperation {}
 #[async_trait]
 impl DatabaseOperation for ColumnOperation {
     async fn generate_sql(&self, datasource: &DatasourceConfig<'static>) {
-        let db_type = datasource.properties.db_type;
+        let db_type = datasource.db_type;
 
         let stmt = match self {
             ColumnOperation::CreateColumn(table_name, entity_field) =>
@@ -1012,7 +1012,7 @@ impl Transaction<Self> for SequenceOperation {}
 #[async_trait]
 impl DatabaseOperation for SequenceOperation {
     async fn generate_sql(&self, datasource: &DatasourceConfig<'static>) {
-        let db_type = datasource.properties.db_type;
+        let db_type = datasource.db_type;
 
         let stmt = match self {
             SequenceOperation::ModifySequence(table_name, entity_field) => {

--- a/canyon_sql/Cargo.toml
+++ b/canyon_sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canyon_sql"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Alex Vergara<pyzyryab@tutanota.com>, Gonzalo Busto<gbm25@gmail.com>"]
 documentation = "https://zerodaycode.github.io/canyon-book/"
@@ -13,7 +13,7 @@ description = "A Rust ORM and QueryBuilder"
 async-trait = { version = "0.1.50" }
 
 # Project crates
-canyon_macros = { version = "0.1.2", path = "../canyon_macros" }
-canyon_observer = { version = "0.1.2", path = "../canyon_observer" }
-canyon_crud = { version = "0.1.2", path = "../canyon_crud" }
-canyon_connection = { version = "0.1.2", path = "../canyon_connection" }
+canyon_macros = { version = "0.2.0", path = "../canyon_macros" }
+canyon_observer = { version = "0.2.0", path = "../canyon_observer" }
+canyon_crud = { version = "0.2.0", path = "../canyon_crud" }
+canyon_connection = { version = "0.2.0", path = "../canyon_connection" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/tests/canyon.toml
+++ b/tests/canyon.toml
@@ -5,7 +5,7 @@ name = 'postgres_docker'
 db_type = 'postgresql'
 
 [canyon_sql.datasources.auth]
-basic = { username = 'postgres', password = 'postgres'}
+postgresql = { basic = { username = 'postgres', password = 'postgres'}}
 
 [canyon_sql.datasources.properties]
 host = 'localhost'
@@ -18,7 +18,7 @@ name = 'sqlserver_docker'
 db_type = 'sqlserver'
 
 [canyon_sql.datasources.auth]
-basic = { username = 'sa', password = 'SqlServer-10' }
+sqlserver = { basic = { username = 'sa', password = 'SqlServer-10' } }
 
 [canyon_sql.datasources.properties]
 host = 'localhost'

--- a/tests/canyon.toml
+++ b/tests/canyon.toml
@@ -1,5 +1,5 @@
 [canyon_sql]
 datasources = [
-    {name = 'postgres_docker', properties.db_type = 'postgresql', properties.username = 'postgres', properties.password = 'postgres', properties.host = 'localhost', properties.port = 5438, properties.db_name = 'postgres'},
-    {name = 'sqlserver_docker', properties.db_type = 'sqlserver', properties.username = 'sa', properties.password = 'SqlServer-10', properties.host = 'localhost', properties.port = 1434, properties.db_name = 'master'}
+    {name = 'postgres_docker', db_type = 'postgresql', properties.username = 'postgres', properties.password = 'postgres', properties.host = 'localhost', properties.port = 5438, properties.db_name = 'postgres'},
+    {name = 'sqlserver_docker', db_type = 'sqlserver', properties.username = 'sa', properties.password = 'SqlServer-10', properties.host = 'localhost', properties.port = 1434, properties.db_name = 'master'}
 ]

--- a/tests/canyon.toml
+++ b/tests/canyon.toml
@@ -2,7 +2,6 @@
 
 [[canyon_sql.datasources]]
 name = 'postgres_docker'
-db_type = 'postgresql'
 
 [canyon_sql.datasources.auth]
 postgresql = { basic = { username = 'postgres', password = 'postgres'}}
@@ -15,7 +14,6 @@ db_name = 'postgres'
 
 [[canyon_sql.datasources]]
 name = 'sqlserver_docker'
-db_type = 'sqlserver'
 
 [canyon_sql.datasources.auth]
 sqlserver = { basic = { username = 'sa', password = 'SqlServer-10' } }

--- a/tests/canyon.toml
+++ b/tests/canyon.toml
@@ -1,5 +1,26 @@
 [canyon_sql]
-datasources = [
-    { name = 'postgres_docker', db_type = 'postgresql', properties.username = 'postgres', properties.password = 'postgres', properties.host = 'localhost', properties.port = 5438, properties.db_name = 'postgres' },
-    { name = 'sqlserver_docker', db_type = 'sqlserver', properties.username = 'sa', properties.password = 'SqlServer-10', properties.host = 'localhost', properties.port = 1434, properties.db_name = 'master' }
-]
+
+[[canyon_sql.datasources]]
+name = 'postgres_docker'
+db_type = 'postgresql'
+
+[canyon_sql.datasources.auth]
+basic = { username = 'postgres', password = 'postgres'}
+
+[canyon_sql.datasources.properties]
+host = 'localhost'
+port = 5438
+db_name = 'postgres'
+
+
+[[canyon_sql.datasources]]
+name = 'sqlserver_docker'
+db_type = 'sqlserver'
+
+[canyon_sql.datasources.auth]
+basic = { username = 'sa', password = 'SqlServer-10' }
+
+[canyon_sql.datasources.properties]
+host = 'localhost'
+port = 1434
+db_name = 'master'

--- a/tests/canyon.toml
+++ b/tests/canyon.toml
@@ -1,5 +1,5 @@
 [canyon_sql]
 datasources = [
-    {name = 'postgres_docker', db_type = 'postgresql', properties.username = 'postgres', properties.password = 'postgres', properties.host = 'localhost', properties.port = 5438, properties.db_name = 'postgres'},
-    {name = 'sqlserver_docker', db_type = 'sqlserver', properties.username = 'sa', properties.password = 'SqlServer-10', properties.host = 'localhost', properties.port = 1434, properties.db_name = 'master'}
+    { name = 'postgres_docker', db_type = 'postgresql', properties.username = 'postgres', properties.password = 'postgres', properties.host = 'localhost', properties.port = 5438, properties.db_name = 'postgres' },
+    { name = 'sqlserver_docker', db_type = 'sqlserver', properties.username = 'sa', properties.password = 'SqlServer-10', properties.host = 'localhost', properties.port = 1434, properties.db_name = 'master' }
 ]


### PR DESCRIPTION
This PR aims to rework the `Canyon Connector`, which is the resposible for instanciate and store the database connections for the defined datasources targetted in the configuration file.

Also, this closes #37 where we introduced a new configuration parameter to specify the kind of authorization which will be used in the SqlServer connections